### PR TITLE
Highlightable family links

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ It is recommended to use Open Sans font as it is preconfigured so minimal additi
     - `monochromeLabels` - If the label color system has no benefit for end-user, it is better to set this attribute to 1. It means colors will be ignored in favor of default styles and switched accordingly when activating the light/dark theme.  
     - `gaTrackingId` - For analyzing the web app traffic via Google Analytics just specify your tracking ID.
     - `highlightMode` - If set to 1 (for paternal line) or 2 (for maternal line), the color of terminal individuals is propagated upstream and combined with colors of connected trees. Intended for reduced family tree containing just tested individuals and their common ancestors.
+    - `selectableFamilyLines` - If set to 1, the family lines can be selected and highlighted. That is especially helpful with very large trees.
 
     Example: `java -jar C:\genopro-webapp-exporter.jar -in:"C:\family-tree.gno" -out:"C:\family-tree" -mode:static -locale:cs -anonymizedYears:120 -datePattern:dd.MM.yyyy -fontFamily:Muli -relativeFontPath:res/Muli-Regular-webfont.woff -gaTrackingId:UA-00000000-1`
 

--- a/README.md
+++ b/README.md
@@ -173,10 +173,10 @@ It is recommended to use Open Sans font as it is preconfigured so minimal additi
     - `fontFamily` - If default Open Sans font doesn't suit your needs, it can be overridden by this parameter. In this case the `relativeFontPath` option becomes mandatory. If the font family contains a space, the value needs to be enclosed in quotes. 
     - `relativeFontPath` - The relative path to the custom font in the WOFF format.
     - `unsupportedLabelHexColorSet` - For suppressing some private labels you can set a specific background color to them and then specify this color or comma delimited set of colors in curly braces, e.g. {#FF0000,#C8C8FF}.
-    - `monochromeLabels` - If the label color system has no benefit for end-user, it is better to set this attribute to 1. It means colors will be ignored in favor of default styles and switched accordingly when activating the light/dark theme.  
+    - `monochromeLabels` - If the label color system has no benefit for end-user, it is better to set this attribute to 1. It means colors will be ignored in favor of default styles and switched accordingly when activating the light/dark theme.
+    - `selectableFamilyLines` - If set to 1, the family lines can be selected and highlighted. That is especially helpful with very large trees.
     - `gaTrackingId` - For analyzing the web app traffic via Google Analytics just specify your tracking ID.
     - `highlightMode` - If set to 1 (for paternal line) or 2 (for maternal line), the color of terminal individuals is propagated upstream and combined with colors of connected trees. Intended for reduced family tree containing just tested individuals and their common ancestors.
-    - `selectableFamilyLines` - If set to 1, the family lines can be selected and highlighted. That is especially helpful with very large trees.
 
     Example: `java -jar C:\genopro-webapp-exporter.jar -in:"C:\family-tree.gno" -out:"C:\family-tree" -mode:static -locale:cs -anonymizedYears:120 -datePattern:dd.MM.yyyy -fontFamily:Muli -relativeFontPath:res/Muli-Regular-webfont.woff -gaTrackingId:UA-00000000-1`
 

--- a/src/main/java/in/drifted/tools/genopro/webapp/exporter/App.java
+++ b/src/main/java/in/drifted/tools/genopro/webapp/exporter/App.java
@@ -54,9 +54,9 @@ public class App {
     private static final String PARAM_RELATIVE_FONT_PATH = "-relativeFontPath";
     private static final String PARAM_UNSUPPORTED_LABEL_HEX_COLOR_SET = "-unsupportedLabelHexColorSet";
     private static final String PARAM_MONOCHROME_LABELS = "-monochromeLabels";
+    private static final String PARAM_SELECTABLE_FAMILY_LINES = "-selectableFamilyLines";
     private static final String PARAM_GA_TRACKING_ID = "-gaTrackingId";
     private static final String PARAM_HIGHLIGHT_MODE = "-highlightMode";
-    private static final String PARAM_SELECTABLE_FAMILY_LINES = "-selectableFamilyLines";
 
     private static final String DEFAULT_MODE = "dynamic";
     private static final int DEFAULT_ANONYMIZED_YEARS = 100;
@@ -179,7 +179,7 @@ public class App {
 
             GeneratingOptions generatingOptions = new GeneratingOptions(locale, resourceBundle, fontFamily,
                     displayStyle, dateFormatter, ageFormatter, unsupportedLabelColorSet, monochromeLabels,
-                    additionalOptionMap, selectableFamilyLines);
+                    selectableFamilyLines, additionalOptionMap);
 
             if (dynamic) {
                 WebAppExporter.export(reportPath, documentInfo, genoMapDataList, generatingOptions);
@@ -206,9 +206,9 @@ public class App {
                     + "        [-relativeFontPath:\"res/OpenSans-Regular-webfont.woff\"] \n"
                     + "        [-unsupportedLabelHexColorSet:{<empty>}], example: {#FF0000,#C8C8FF}\n"
                     + "        [-monochromeLabels:0]\n"
+                    + "        [-selectableFamilyLines:0]\n"
                     + "        [-gaTrackingId:<empty>]\n"
                     + "        [-highlightMode:0]\n"
-                    + "        [-selectableFamilyLines:0]\n"
             );
         }
     }

--- a/src/main/java/in/drifted/tools/genopro/webapp/exporter/App.java
+++ b/src/main/java/in/drifted/tools/genopro/webapp/exporter/App.java
@@ -56,6 +56,7 @@ public class App {
     private static final String PARAM_MONOCHROME_LABELS = "-monochromeLabels";
     private static final String PARAM_GA_TRACKING_ID = "-gaTrackingId";
     private static final String PARAM_HIGHLIGHT_MODE = "-highlightMode";
+    private static final String PARAM_SELECTABLE_FAMILY_LINES = "-selectableFamilyLines";
 
     private static final String DEFAULT_MODE = "dynamic";
     private static final int DEFAULT_ANONYMIZED_YEARS = 100;
@@ -169,9 +170,16 @@ public class App {
                 dateFormatter = new DateFormatter("yyyy", locale, dateFormatter.getPrefixReplacementMap());
             }
 
+            boolean selectableFamilyLines = false;
+            if (passedValuesMap.containsKey(PARAM_SELECTABLE_FAMILY_LINES)) {
+                if(Integer.parseInt(passedValuesMap.get(PARAM_SELECTABLE_FAMILY_LINES)) > 0) {
+                    selectableFamilyLines = true;
+                }
+            }
+
             GeneratingOptions generatingOptions = new GeneratingOptions(locale, resourceBundle, fontFamily,
                     displayStyle, dateFormatter, ageFormatter, unsupportedLabelColorSet, monochromeLabels,
-                    additionalOptionMap);
+                    additionalOptionMap, selectableFamilyLines);
 
             if (dynamic) {
                 WebAppExporter.export(reportPath, documentInfo, genoMapDataList, generatingOptions);
@@ -200,6 +208,7 @@ public class App {
                     + "        [-monochromeLabels:0]\n"
                     + "        [-gaTrackingId:<empty>]\n"
                     + "        [-highlightMode:0]\n"
+                    + "        [-selectableFamilyLines:0]\n"
             );
         }
     }

--- a/src/main/java/in/drifted/tools/genopro/webapp/exporter/SvgExporter.java
+++ b/src/main/java/in/drifted/tools/genopro/webapp/exporter/SvgExporter.java
@@ -270,6 +270,7 @@ public class SvgExporter {
             Map<String, Individual> individualMap, int shiftX, int shiftY, GeneratingOptions generatingOptions)
             throws XMLStreamException {
 
+        String familyId = family.getId();
         Position position = family.getPosition();
         BoundaryRect topBoundaryRect = family.getTopBoundaryRect();
         BoundaryRect bottomBoundaryRect = family.getBottomBoundaryRect();
@@ -346,10 +347,10 @@ public class SvgExporter {
                             writer.writeAttribute("d", linePathDataArray[0]);
 
                             if (highlightMode == HighlightMode.PATERNAL) {
-                                writer.writeAttribute("class", className + " highlighted");
+                                writer.writeAttribute("class", className + " highlighted " + familyId);
                                 writer.writeAttribute("style", style.toString());
                             } else {
-                                writer.writeAttribute("class", className + " unhighlighted");
+                                writer.writeAttribute("class", className + " unhighlighted " + familyId);
                             }
 
                             writer.writeEndElement();
@@ -358,10 +359,10 @@ public class SvgExporter {
                             writer.writeAttribute("d", linePathDataArray[1]);
 
                             if (highlightMode == HighlightMode.MATERNAL) {
-                                writer.writeAttribute("class", className + " highlighted");
+                                writer.writeAttribute("class", className + " highlighted " + familyId);
                                 writer.writeAttribute("style", style.toString());
                             } else {
-                                writer.writeAttribute("class", className + " unhighlighted");
+                                writer.writeAttribute("class", className + " unhighlighted " + familyId);
                             }
 
                             writer.writeEndElement();
@@ -369,7 +370,7 @@ public class SvgExporter {
                         } else {
                             writer.writeStartElement("path");
                             writer.writeAttribute("d", linePathData);
-                            writer.writeAttribute("class", className + " highlighted");
+                            writer.writeAttribute("class", className + " highlighted " + familyId);
                             writer.writeAttribute("style", style.toString());
                             writer.writeEndElement();
                         }
@@ -380,14 +381,14 @@ public class SvgExporter {
                 } else {
                     writer.writeStartElement("path");
                     writer.writeAttribute("d", linePathData);
-                    writer.writeAttribute("class", className + " unhighlighted");
+                    writer.writeAttribute("class", className + " unhighlighted " + familyId);
                     writer.writeEndElement();
                 }
 
             } else {
                 writer.writeStartElement("path");
                 writer.writeAttribute("d", linePathData);
-                writer.writeAttribute("class", className);
+                writer.writeAttribute("class", className + " " + familyId);
                 writer.writeEndElement();
             }
 
@@ -496,13 +497,13 @@ public class SvgExporter {
 
                         writer.writeStartElement("path");
                         writer.writeAttribute("d", verticalPathData.toString());
-                        writer.writeAttribute("class", className + " highlighted");
+                        writer.writeAttribute("class", className + " highlighted " + familyId);
                         writer.writeAttribute("style", style.toString());
                         writer.writeEndElement();
 
                         writer.writeStartElement("path");
                         writer.writeAttribute("d", horizontalPathData.toString());
-                        writer.writeAttribute("class", className + " highlighted");
+                        writer.writeAttribute("class", className + " highlighted " + familyId);
                         writer.writeAttribute("style", style.toString());
                         writer.writeEndElement();
 
@@ -512,12 +513,12 @@ public class SvgExporter {
                 } else {
                     writer.writeStartElement("path");
                     writer.writeAttribute("d", verticalPathData.toString());
-                    writer.writeAttribute("class", className);
+                    writer.writeAttribute("class", className + " " + familyId);
                     writer.writeEndElement();
 
                     writer.writeStartElement("path");
                     writer.writeAttribute("d", horizontalPathData.toString());
-                    writer.writeAttribute("class", className);
+                    writer.writeAttribute("class", className + " " + familyId);
                     writer.writeEndElement();
                 }
             }
@@ -608,7 +609,7 @@ public class SvgExporter {
 
                             writer.writeStartElement("path");
                             writer.writeAttribute("d", pathData.toString());
-                            writer.writeAttribute("class", className + " highlighted");
+                            writer.writeAttribute("class", className + " highlighted " + familyId);
                             writer.writeAttribute("style", style.toString());
                             writer.writeEndElement();
 
@@ -618,7 +619,7 @@ public class SvgExporter {
                     } else {
                         writer.writeStartElement("path");
                         writer.writeAttribute("d", pathData.toString());
-                        writer.writeAttribute("class", className + " unhighlighted");
+                        writer.writeAttribute("class", className + " unhighlighted " + familyId);
                         writer.writeEndElement();
                     }
 
@@ -629,15 +630,15 @@ public class SvgExporter {
                     switch (pedigreeLink.getPedigreeLinkType()) {
 
                         case PARENT:
-                            writer.writeAttribute("class", className + " parent");
+                            writer.writeAttribute("class", className + " parent " + familyId);
                             break;
 
                         case ADOPTED:
-                            writer.writeAttribute("class", className + " adopted");
+                            writer.writeAttribute("class", className + " adopted " + familyId);
                             break;
 
                         default:
-                            writer.writeAttribute("class", className + " biological");
+                            writer.writeAttribute("class", className + " biological " + familyId);
                             break;
                     }
 

--- a/src/main/java/in/drifted/tools/genopro/webapp/exporter/WebAppExporter.java
+++ b/src/main/java/in/drifted/tools/genopro/webapp/exporter/WebAppExporter.java
@@ -123,6 +123,7 @@ public class WebAppExporter {
                 script = script.replace("${" + placeholder + "}", generatingOptions.getResourceBundle().getString(placeholder));
             }
             script = script.replace("\"${dynamic}\"", dynamic ? "true" : "false");
+            script = script.replace("${selectableFamilyLines}", generatingOptions.getSelectableFamilyLines() ? "true" : "false");
 
             writer.write(script.replaceAll("\\s+", " "));
         }

--- a/src/main/java/in/drifted/tools/genopro/webapp/exporter/model/GeneratingOptions.java
+++ b/src/main/java/in/drifted/tools/genopro/webapp/exporter/model/GeneratingOptions.java
@@ -48,11 +48,12 @@ public class GeneratingOptions {
     private final Set<Color> unsupportedLabelColorSet;
     private final boolean monochromeLabels;
     private final Map<String, String> additionalOptionsMap;
+    private final boolean selectableFamilyLines;
 
     public GeneratingOptions(Locale locale, ResourceBundle resourceBundle, String fontFamily,
             DisplayStyle displayStyle, DateFormatter dateFormatter, AgeFormatter ageFormatter,
             Set<Color> unsupportedLabelColorSet, boolean monochromeLabels,
-            Map<String, String> additionalOptionsMap) {
+            Map<String, String> additionalOptionsMap, boolean selectableFamilyLines) {
 
         Canvas canvas = new Canvas();
 
@@ -74,6 +75,7 @@ public class GeneratingOptions {
         this.unsupportedLabelColorSet = unsupportedLabelColorSet;
         this.monochromeLabels = monochromeLabels;
         this.additionalOptionsMap = additionalOptionsMap;
+        this.selectableFamilyLines = selectableFamilyLines;
     }
 
     public FontMetrics getFontMetrics(double sizeInPixels) {
@@ -122,6 +124,10 @@ public class GeneratingOptions {
 
     public Map<String, String> getAdditionalOptionsMap() {
         return additionalOptionsMap;
+    }
+
+    public boolean getSelectableFamilyLines() {
+        return selectableFamilyLines;
     }
 
 }

--- a/src/main/java/in/drifted/tools/genopro/webapp/exporter/model/GeneratingOptions.java
+++ b/src/main/java/in/drifted/tools/genopro/webapp/exporter/model/GeneratingOptions.java
@@ -53,7 +53,7 @@ public class GeneratingOptions {
     public GeneratingOptions(Locale locale, ResourceBundle resourceBundle, String fontFamily,
             DisplayStyle displayStyle, DateFormatter dateFormatter, AgeFormatter ageFormatter,
             Set<Color> unsupportedLabelColorSet, boolean monochromeLabels,
-            Map<String, String> additionalOptionsMap, boolean selectableFamilyLines) {
+            boolean selectableFamilyLines, Map<String, String> additionalOptionsMap) {
 
         Canvas canvas = new Canvas();
 

--- a/src/main/resources/in/drifted/tools/genopro/webapp/exporter/resources/template/main.js
+++ b/src/main/resources/in/drifted/tools/genopro/webapp/exporter/resources/template/main.js
@@ -167,16 +167,18 @@ function switchGenoMap(callback) {
 }
 
 function initSvgListeners() {
-    const familyLines = document.getElementsByClassName("family-line");
-    for (let i = 0; i < familyLines.length; i++) {
-        familyLines[i].addEventListener("touchend", selectPath);
-        familyLines[i].addEventListener("mousedown", selectPath);
-    }
+    if ("${selectableFamilyLines}" === "true") {
+        const familyLines = document.getElementsByClassName("family-line");
+        for (let i = 0; i < familyLines.length; i++) {
+            familyLines[i].addEventListener("touchend", selectPath);
+            familyLines[i].addEventListener("mousedown", selectPath);
+        }
 
-    const pedigreeLinks = document.getElementsByClassName("pedigree-link");
-    for (let i = 0; i < pedigreeLinks.length; i++) {
-        pedigreeLinks[i].addEventListener("touchend", selectPath);
-        pedigreeLinks[i].addEventListener("mousedown", selectPath);
+        const pedigreeLinks = document.getElementsByClassName("pedigree-link");
+        for (let i = 0; i < pedigreeLinks.length; i++) {
+            pedigreeLinks[i].addEventListener("touchend", selectPath);
+            pedigreeLinks[i].addEventListener("mousedown", selectPath);
+        }
     }
 
     const individuals = document.getElementsByClassName("individual-active-area");

--- a/src/main/resources/in/drifted/tools/genopro/webapp/exporter/resources/template/main.js
+++ b/src/main/resources/in/drifted/tools/genopro/webapp/exporter/resources/template/main.js
@@ -167,6 +167,17 @@ function switchGenoMap(callback) {
 }
 
 function initSvgListeners() {
+    const familyLines = document.getElementsByClassName("family-line");
+    for (let i = 0; i < familyLines.length; i++) {
+        familyLines[i].addEventListener("touchend", selectPath);
+        familyLines[i].addEventListener("mousedown", selectPath);
+    }
+
+    const pedigreeLinks = document.getElementsByClassName("pedigree-link");
+    for (let i = 0; i < pedigreeLinks.length; i++) {
+        pedigreeLinks[i].addEventListener("touchend", selectPath);
+        pedigreeLinks[i].addEventListener("mousedown", selectPath);
+    }
 
     const individuals = document.getElementsByClassName("individual-active-area");
     for (let i = 0; i < individuals.length; i++) {
@@ -320,6 +331,33 @@ function select(e) {
     e.preventDefault();
 
     selectById(e.target.parentElement.id);
+}
+
+function selectPath(e) {
+    e.preventDefault();
+
+    /* remove previous link highlights */
+    const highlightedLinks = document.getElementsByClassName("link-highlight");
+    while (highlightedLinks.length > 0) {
+       highlightedLinks[0].classList.remove("link-highlight");
+    }
+
+    /* find family ID of the selected element */
+    const classes = e.target.classList;
+    let familyClass;
+    for (let i = 0; i < classes.length; i++) {
+        if ( /^fam[0-9]+/.test(classes[i]) ) {
+            familyClass = classes[i];
+            break;
+        }
+    }
+
+    /* add highlight class to all elements with the same family ID */
+    const paths = document.getElementsByClassName(familyClass);
+    for (let i = 0; i < paths.length; i++) {
+        paths[i].classList.add("link-highlight");
+    }
+
 }
 
 function selectById(id) {

--- a/src/main/resources/in/drifted/tools/genopro/webapp/exporter/resources/template/style.css
+++ b/src/main/resources/in/drifted/tools/genopro/webapp/exporter/resources/template/style.css
@@ -159,6 +159,13 @@ path.pedigree-link.adopted {
     stroke-width: 3px;
 }
 
+path.family-line.link-highlight,
+path.pedigree-link.link-highlight {
+    fill: none;
+    stroke: var(--individual-highlight-color);
+    stroke-width: 3px;
+}
+
 .monochrome-label {
     fill: var(--monochrome-label-background-color);
     stroke: var(--monochrome-label-border-color);


### PR DESCRIPTION
Hello! 
At first, let me say thank you for a wonderful library and exporter app.

This PR adds click event listeners and family ID (as another class) to all family line and pedigree link elements. 
Clicking any of the elements causes that all elements with the same family ID class are highlighted. 
This is especially helpful when you deal with a large tree (as I do; tree of the whole village with 2.5k persons) where siblings are spread all over the map and it's difficult to follow the lines. 

Unfortunately, there is one issue with this feature - it's unusable on touch devices because the click area is too small to hit it with a finger. I don't mind it that much since a tree as big as I have is hardly usable on mobile phones anyway so I'm just mentioning it if anyone knows about an elegant way how to fix this.